### PR TITLE
Move network operations (git/wget/curl) under dir conditional check

### DIFF
--- a/win32_build.sh
+++ b/win32_build.sh
@@ -73,7 +73,8 @@ if [[ -n $CLEAN_BUILD ]]; then
     rm -rf $BUILD_DIR
 fi
 
-if [[ ! -d $DEPS_DIR ]]; then
+# If libdokan.a doesn't exist, build the dependencies
+if [[ ! -f ${dokanLibDir}/libdokan.a ]]; then
     echo "Preparing dependencies: $DEPS_DIR"
     NUM_WORKERS=$NUM_WORKERS DEPS_DIR=$DEPS_DIR \
         "$SCRIPT_DIR/win32_deps_build.sh"

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -29,8 +29,8 @@ boostSrcDir="${depsSrcDir}/boost_1_70_0"
 boostDir="${depsToolsetDir}/boost"
 zlibDir="${depsToolsetDir}/zlib"
 zlibSrcDir="${depsSrcDir}/zlib"
-backtraceDir="${depsToolsetDir}/backtrace"
-backtraceSrcDir="${depsSrcDir}/backtrace"
+backtraceDir="${depsToolsetDir}/libbacktrace"
+backtraceSrcDir="${depsSrcDir}/libbacktrace"
 snappySrcDir="${depsSrcDir}/snappy"
 snappyDir="${depsToolsetDir}/snappy"
 snappyTag="1.1.7"
@@ -74,10 +74,10 @@ sudo apt-get -y install mingw-w64 cmake pkg-config python3-dev python3-pip \
 sudo python3 -m pip install cython
 
 cd $depsSrcDir
-if [[ ! -d $zlibDir ]]; then
+if [[ ! -d $zlibSrcDir ]]; then
     git clone https://github.com/madler/zlib
 fi
-cd zlib
+cd $zlibSrcDir
 # Apparently the configure script is broken...
 sed -e s/"PREFIX = *$"/"PREFIX = x86_64-w64-mingw32-"/ -i win32/Makefile.gcc
 _make -f win32/Makefile.gcc
@@ -90,9 +90,9 @@ _make BINARY_PATH=$zlibDir \
 cd $depsToolsetDir
 if [[ ! -d $lz4Dir ]]; then
     git clone https://github.com/lz4/lz4
+    cd $lz4Dir; git checkout $lz4Tag
 fi
-cd lz4
-git checkout $lz4Tag
+cd $lz4Dir
 _make BUILD_STATIC=no CC=x86_64-w64-mingw32-gcc \
       DLLTOOL=x86_64-w64-mingw32-dlltool \
       WINDRES=x86_64-w64-mingw32-windres \
@@ -113,9 +113,9 @@ _make install
 cd $depsSrcDir
 if [[ ! -d $curlSrcDir ]]; then
     git clone https://github.com/curl/curl
+    cd $curlSrcDir && git checkout $curlTag
 fi
 cd $curlSrcDir
-git checkout $curlTag
 ./buildconf
 ./configure --prefix=$curlDir --with-ssl=$sslDir --with-zlib=$zlibDir \
             --host=x86_64-w64-mingw32
@@ -265,8 +265,8 @@ cd $depsSrcDir
 if [[ ! -d $backtraceSrcDir ]]; then
     git clone https://github.com/ianlancetaylor/libbacktrace
 fi
-mkdir libbacktrace/build
-cd libbacktrace/build
+mkdir -p $backtraceSrcDir/build
+cd $backtraceSrcDir/build
 ../configure --prefix=$backtraceDir --exec-prefix=$backtraceDir \
              --host x86_64-w64-mingw32 --enable-host-shared
 _make LDFLAGS="-no-undefined"
@@ -276,10 +276,10 @@ cp $backtraceDir/lib/libbacktrace.a $backtraceDir/lib/libbacktrace.dll.a
 cd $depsSrcDir
 if [[ ! -d $snappySrcDir ]]; then
     git clone https://github.com/google/snappy
+    cd $snappySrcDir && git checkout $snappyTag
 fi
-mkdir -p snappy/build
-cd snappy && git checkout $snappyTag
-cd build
+mkdir -p $snappySrcDir/build
+cd $snappySrcDir/build
 
 cmake -DCMAKE_INSTALL_PREFIX=$snappyDir \
       -DCMAKE_BUILD_TYPE=Release \
@@ -337,9 +337,9 @@ x86_64-w64-mingw32-dlltool -d $winLibDir/mswsock.def \
 cd $depsSrcDir
 if [[ ! -d $dokanSrcDir ]]; then
     git clone $dokanUrl
+    cd $dokanSrcDir && git checkout $dokanTag
 fi
 cd $dokanSrcDir
-git checkout $dokanTag
 
 mkdir -p $dokanLibDir
 x86_64-w64-mingw32-dlltool -d $dokanSrcDir/dokan/dokan.def \


### PR DESCRIPTION
The main purpose of this commit is to isolate the network operations (git/wget/curl) related to dependencies to within the conditional check of the source code directories. This allows for these sources to be extracted/setup outside of the script, while still allowing the script to be used for configuration and building.

This commit also includes the following minor changes:

 - Corrects the naming of the backtrace directory variables
 - Corrects the directory source check for zlib
 - Switches to the $zlibSrcDir variable, instead of 'zlib'
 - Switches to the $lz4Dir variable, instead of 'lz4'
 - Switches to the $backtraceSrcDir variable, instead of 'backtrace'

Signed-off-by: Mike Latimer <mlatimer@suse.com>