### PR TITLE
Find cpp17 std filesystem

### DIFF
--- a/cmake/modules/FindStdFilesystem.cmake
+++ b/cmake/modules/FindStdFilesystem.cmake
@@ -18,6 +18,9 @@ endmacro()
 
 
 if(NOT StdFilesystem_LIBRARY)
+  try_std_filesystem_library("stdc++" StdFilesystem_LIBRARY)
+endif()
+if(NOT StdFilesystem_LIBRARY)
   try_std_filesystem_library("stdc++fs" StdFilesystem_LIBRARY)
 endif()
 if(NOT StdFilesystem_LIBRARY)

--- a/src/test/admin_socket_output.cc
+++ b/src/test/admin_socket_output.cc
@@ -14,7 +14,11 @@
 
 #include <iostream>
 #include <regex>                 // For regex, regex_search
-#include <experimental/filesystem> // For extension
+#if __cplusplus >= 201703L && __has_include(<filesystem>)  // For extension
+#include <filesystem>
+#else
+#include <experimental/filesystem>
+#endif
 
 #include "common/admin_socket_client.h"     // For AdminSocketClient
 #include "common/ceph_json.h"               // For JSONParser, JSONObjIter

--- a/src/test/admin_socket_output.h
+++ b/src/test/admin_socket_output.h
@@ -19,9 +19,13 @@
 #include <map>
 #include <set>
 #include <vector>
-#include <experimental/filesystem>       // For path
-
+#if __cplusplus >= 201703L && __has_include(<filesystem>)   // For path
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
+#endif
 
 using socket_results = std::map<std::string, std::string>;
 using test_functions =

--- a/src/test/common/test_util.cc
+++ b/src/test/common/test_util.cc
@@ -16,7 +16,11 @@
 #include "include/util.h"
 #include "gtest/gtest.h"
 
+#if __cplusplus >= 201703L && __has_include(<filesystem>)
+#include <filesystem>
+#else
 #include <experimental/filesystem>
+#endif
 
 #if defined(__linux__)
 TEST(util, collect_sys_info)

--- a/src/test/libcephfs_config.cc
+++ b/src/test/libcephfs_config.cc
@@ -13,6 +13,7 @@
  */
 
 #include "gtest/gtest.h"
+#include "include/compat.h"
 #include "include/cephfs/libcephfs.h"
 
 #include <sstream>

--- a/src/tools/immutable_object_cache/ObjectCacheStore.cc
+++ b/src/tools/immutable_object_cache/ObjectCacheStore.cc
@@ -3,7 +3,13 @@
 
 #include "ObjectCacheStore.h"
 #include "Utils.h"
+#if __cplusplus >= 201703L && __has_include(<filesystem>)
+#include <filesystem>
+namespace efs = std::filesystem;
+#else
 #include <experimental/filesystem>
+namespace efs = std::experimental::filesystem;
+#endif
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_immutable_obj_cache
@@ -11,7 +17,6 @@
 #define dout_prefix *_dout << "ceph::cache::ObjectCacheStore: " << this << " " \
                            << __func__ << ": "
 
-namespace efs = std::experimental::filesystem;
 
 namespace ceph {
 namespace immutable_obj_cache {


### PR DESCRIPTION
In C++17 environments (gcc 8+) StdFilesystem::filesystem has been moved from libstdc++fs to the standard libstdc++. This commit adds that library to FindStdFilesystem.cmake, and modifies includes and namespaces to conditionally use <filesystem> (for 2017+) and <experimental/filesystem> for older environments.

Signed-off-by: Mike Latimer <mlatimer@suse.com>