### PR TITLE
win32: minor cleanup, plus distro package installs

### DIFF
--- a/README.windows.rst
+++ b/README.windows.rst
@@ -98,7 +98,8 @@ Configuring
 
 The default location for the ``ceph.conf`` file on Windows is
 ``%ProgramData%\ceph\ceph.conf``, which usually expands to
-``C:\ProgramFiles\ceph\ceph.conf``.
+``C:\ProgramData\ceph\ceph.conf``. (Note - Directories with spaces
+in their names are not currently supported.)
 
 Below you may find a sample. Please fill in the monitor addresses
 accordingly.

--- a/win32_build.sh
+++ b/win32_build.sh
@@ -191,12 +191,17 @@ if [[ -n $BUILD_ZIP ]]; then
     # Use a temp directory, in order to create a clean zip file
     ZIP_TMPDIR=$(mktemp -d win_binaries.XXXXX)
     if [[ -n $STRIP_ZIPPED ]]; then
-        rm -rf $strippedBinDir
-        echo "Copying binaries to $strippedBinDir."
-        cp -r $binDir $strippedBinDir
         echo "Stripping debug symbols from binaries."
-        $MINGW_STRIP $strippedBinDir/*.exe \
-                     $strippedBinDir/*.dll
+        rm -rf $strippedBinDir; mkdir $strippedBinDir
+        # Strip files individually, to save time and space
+        for file in $binDir/*.exe $binDir/*.dll; do
+            $MINGW_STRIP -o $strippedBinDir/$(basename $file) $file
+        done
+        # Copy any remaining files to the stripped directory
+        for file in $binDir/*; do
+            [[ ! -f $strippedBinDir/$(basename $file) ]] && \
+                cp $file $strippedBinDir
+        done
         ln -s $strippedBinDir $ZIP_TMPDIR/ceph
     else
         ln -s $binDir $ZIP_TMPDIR/ceph

--- a/win32_build.sh
+++ b/win32_build.sh
@@ -188,13 +188,25 @@ if [[ -z $SKIP_DLL_COPY ]]; then
 fi
 
 if [[ -n $BUILD_ZIP ]]; then
+    # Use a temp directory, in order to create a clean zip file
+    ZIP_TMPDIR=$(mktemp -d win_binaries.XXXXX)
     if [[ -n $STRIP_ZIPPED ]]; then
         rm -rf $strippedBinDir
+        echo "Copying binaries to $strippedBinDir."
         cp -r $binDir $strippedBinDir
-        echo "Stripping debug symbols from $strippedBinDir binaries."
+        echo "Stripping debug symbols from binaries."
         $MINGW_STRIP $strippedBinDir/*.exe \
                      $strippedBinDir/*.dll
+        ln -s $strippedBinDir $ZIP_TMPDIR/ceph
+    else
+        ln -s $binDir $ZIP_TMPDIR/ceph
     fi
     echo "Building zip archive $ZIP_DEST."
-    zip -r $ZIP_DEST $strippedBinDir
+    # Include the README file in the archive
+    ln -s $CEPH_DIR/README.windows.rst $ZIP_TMPDIR/ceph/README.windows.rst
+    cd $ZIP_TMPDIR
+    zip -r $ZIP_DEST ceph
+    cd -
+    rm -rf $ZIP_TMPDIR/ceph/README.windows.rst $ZIP_TMPDIR
+    echo -e '\n  WIN32 files zipped to: '$ZIP_DEST'\n'
 fi

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -58,9 +58,20 @@ mkdir -p $depsSrcDir
 MINGW_CMAKE_FILE="$DEPS_DIR/mingw.cmake"
 source "$SCRIPT_DIR/mingw_conf.sh"
 
-sudo apt-get -y install mingw-w64 cmake pkg-config python3-dev python3-pip \
+case "$OS" in
+    ubuntu)
+        sudo apt-get -y install mingw-w64 cmake pkg-config python3-dev python3-pip \
                 autoconf libtool ninja-build zip
-sudo python3 -m pip install cython
+        sudo python3 -m pip install cython
+        ;;
+    suse)
+        for RPM in mingw-w64-cross-gcc cmake pkg-config python3-dev \
+                autoconf libtool ninja zip python3-Cython; do
+            rpm -q $PKG >/dev/null || zypper -n install $RPM
+        done
+        ;;
+esac
+
 
 cd $depsSrcDir
 if [[ ! -d $zlibSrcDir ]]; then


### PR DESCRIPTION
These patches address a few more minor issues encountered during testing.

 - Fix a minor typo in the README.
 - Create the binary archive using a single 'ceph' parent directory, and include the README.
 - Strip binaries individually, to avoid the costly directory copy.
 - Install packages using distro-specific tools.