### PR TITLE
wip: persistent reservations v2

### DIFF
--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -744,6 +744,9 @@ public:
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   int aio_write2(uint64_t off, size_t len, ceph::bufferlist& bl,
 		  RBD::AioCompletion *c, int op_flags);
+  int aio_write3(uint64_t off, size_t len, ceph::bufferlist& bl,
+      RBD::AioCompletion *c, int op_flags,
+      std::optional<uint64_t> assert_tag);
 
   int aio_discard(uint64_t off, uint64_t len, RBD::AioCompletion *c);
   int aio_writesame(uint64_t off, size_t len, ceph::bufferlist& bl,

--- a/src/librbd/api/Io.cc
+++ b/src/librbd/api/Io.cc
@@ -245,7 +245,8 @@ void Io<I>::aio_read(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
 template <typename I>
 void Io<I>::aio_write(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
                       uint64_t len, bufferlist &&bl, int op_flags,
-                      bool native_async) {
+                      bool native_async,
+                      std::optional<uint64_t> assert_tag = std::nullopt) {
   auto cct = image_ctx.cct;
   FUNCTRACE(cct);
   ZTracer::Trace trace;
@@ -270,7 +271,7 @@ void Io<I>::aio_write(I &image_ctx, io::AioCompletion *aio_comp, uint64_t off,
   auto req = io::ImageDispatchSpec::create_write(
       image_ctx, io::IMAGE_DISPATCH_LAYER_API_START, aio_comp,
       {{off, len}}, io::ImageArea::DATA, std::move(bl),
-      image_ctx.get_data_io_context(), op_flags, trace);
+      image_ctx.get_data_io_context(), op_flags, trace, assert_tag);
   req->send();
 }
 

--- a/src/librbd/api/Io.h
+++ b/src/librbd/api/Io.h
@@ -37,7 +37,8 @@ struct Io {
                        bool native_async);
   static void aio_write(ImageCtxT &image_ctx, io::AioCompletion *c,
                         uint64_t off, uint64_t len, bufferlist &&bl,
-                        int op_flags, bool native_async);
+                        int op_flags, bool native_async,
+                        std::optional<uint64_t> assert_tag = std::nullopt);
   static void aio_discard(ImageCtxT &image_ctx, io::AioCompletion *c,
                           uint64_t off, uint64_t len,
                           uint32_t discard_granularity_bytes,

--- a/src/librbd/io/ImageDispatchSpec.h
+++ b/src/librbd/io/ImageDispatchSpec.h
@@ -120,6 +120,7 @@ public:
   IOContext io_context;
   int op_flags;
   ZTracer::Trace parent_trace;
+  std::optional<uint64_t> assert_tag;
   uint64_t tid = 0;
 
   template <typename ImageCtxT = ImageCtx>
@@ -153,12 +154,14 @@ public:
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, Extents &&image_extents, ImageArea area,
       bufferlist &&bl, IOContext io_context, int op_flags,
-      const ZTracer::Trace &parent_trace) {
+      const ZTracer::Trace &parent_trace,
+      std::optional<uint64_t> assert_tag = std::nullopt) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
                                  std::move(image_extents), area,
                                  Write{std::move(bl)},
-                                 io_context, op_flags, parent_trace);
+                                 io_context, op_flags, parent_trace,
+                                 assert_tag);
   }
 
   template <typename ImageCtxT = ImageCtx>
@@ -205,6 +208,7 @@ public:
       ImageCtxT &image_ctx, ImageDispatchLayer image_dispatch_layer,
       AioCompletion *aio_comp, Extents &&image_extents, ImageArea area,
       SnapIds&& snap_ids, int list_snaps_flags, SnapshotDelta* snapshot_delta,
+
       const ZTracer::Trace &parent_trace) {
     return new ImageDispatchSpec(image_ctx.io_image_dispatcher,
                                  image_dispatch_layer, aio_comp,
@@ -230,11 +234,13 @@ private:
                     ImageDispatchLayer image_dispatch_layer,
                     AioCompletion* aio_comp, Extents&& image_extents,
                     ImageArea area, Request&& request, IOContext io_context,
-                    int op_flags, const ZTracer::Trace& parent_trace)
+                    int op_flags, const ZTracer::Trace& parent_trace,
+                    std::optional<uint64_t> assert_tag = std::nullopt)
     : dispatcher_ctx(this), image_dispatcher(image_dispatcher),
       dispatch_layer(image_dispatch_layer), aio_comp(aio_comp),
       image_extents(std::move(image_extents)), request(std::move(request)),
-      io_context(io_context), op_flags(op_flags), parent_trace(parent_trace) {
+      io_context(io_context), op_flags(op_flags), parent_trace(parent_trace),
+      assert_tag(assert_tag) {
     ceph_assert(aio_comp->image_dispatcher_ctx == nullptr);
     aio_comp->image_dispatcher_ctx = &dispatcher_ctx;
     aio_comp->get();

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -119,10 +119,12 @@ ObjectRequest<I>::create_compare_and_write(
 template <typename I>
 ObjectRequest<I>::ObjectRequest(
     I *ictx, uint64_t objectno, IOContext io_context,
-    const char *trace_name, const ZTracer::Trace &trace, Context *completion)
+    const char *trace_name, const ZTracer::Trace &trace, Context *completion,
+    std::optional<uint64_t> assert_tag)
   : m_ictx(ictx), m_object_no(objectno), m_io_context(io_context),
     m_completion(completion),
-    m_trace(create_trace(*ictx, "", trace)) {
+    m_trace(create_trace(*ictx, "", trace)),
+    m_assert_tag(assert_tag) {
   ceph_assert(m_ictx->data_ctx.is_valid());
   if (m_trace.valid()) {
     m_trace.copy_name(trace_name + std::string(" ") +
@@ -141,6 +143,15 @@ void ObjectRequest<I>::add_write_hint(I& image_ctx, neorados::WriteOp* wr) {
                        alloc_hint_flags);
   } else if (image_ctx.alloc_hint_flags != 0U) {
     wr->set_alloc_hint(0, 0, alloc_hint_flags);
+  }
+}
+
+template <typename I>
+void ObjectRequest<I>::add_tag_check(neorados::Op* op) {
+  if (m_assert_tag.has_value()) {
+    bufferlist bl;
+    bl.append(std::to_string(m_assert_tag.value()));
+    op->cmpxattr("tag", neorados::cmpxattr_op::eq, bl);
   }
 }
 
@@ -362,9 +373,10 @@ template <typename I>
 AbstractObjectWriteRequest<I>::AbstractObjectWriteRequest(
     I *ictx, uint64_t object_no, uint64_t object_off, uint64_t len,
     IOContext io_context, const char *trace_name,
-    const ZTracer::Trace &parent_trace, Context *completion)
+    const ZTracer::Trace &parent_trace, Context *completion,
+    std::optional<uint64_t> assert_tag)
   : ObjectRequest<I>(ictx, object_no, io_context, trace_name, parent_trace,
-                     completion),
+                     completion, assert_tag),
     m_object_off(object_off), m_object_len(len)
 {
   if (this->m_object_off == 0 &&
@@ -505,6 +517,7 @@ void AbstractObjectWriteRequest<I>::write_object() {
     }
   }
 
+  this->add_tag_check(&write_op);
   add_write_hint(&write_op);
   add_write_ops(&write_op);
   ceph_assert(write_op.size() != 0);
@@ -655,11 +668,6 @@ void ObjectWriteRequest<I>::add_write_hint(neorados::WriteOp* wr) {
     wr->create(true);
   } else if (m_assert_version.has_value()) {
     wr->assert_version(m_assert_version.value());
-  } else if (m_assert_tag.has_value()) {
-    // TODO: consider moving this to ObjectRequest.
-    bufferlist bl;
-    bl.append(std::to_string(m_assert_tag.value()));
-    wr->cmpxattr("tag", neorados::cmpxattr_op::eq, bl);
   }
   AbstractObjectWriteRequest<I>::add_write_hint(wr);
 }

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -72,11 +72,12 @@ ObjectRequest<I>::create_write(
     I *ictx, uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
     IOContext io_context, int op_flags, int write_flags,
     std::optional<uint64_t> assert_version,
-    const ZTracer::Trace &parent_trace, Context *completion) {
+    const ZTracer::Trace &parent_trace, Context *completion,
+    std::optional<uint64_t> assert_tag) {
   return new ObjectWriteRequest<I>(ictx, object_no, object_off,
                                    std::move(data), io_context, op_flags,
                                    write_flags, assert_version,
-                                   parent_trace, completion);
+                                   parent_trace, completion, assert_tag);
 }
 
 template <typename I>
@@ -654,6 +655,11 @@ void ObjectWriteRequest<I>::add_write_hint(neorados::WriteOp* wr) {
     wr->create(true);
   } else if (m_assert_version.has_value()) {
     wr->assert_version(m_assert_version.value());
+  } else if (m_assert_tag.has_value()) {
+    // TODO: consider moving this to ObjectRequest.
+    bufferlist bl;
+    bl.append(std::to_string(m_assert_tag.value()));
+    wr->cmpxattr("tag", neorados::cmpxattr_op::eq, bl);
   }
   AbstractObjectWriteRequest<I>::add_write_hint(wr);
 }

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -40,7 +40,8 @@ public:
       ImageCtxT *ictx, uint64_t object_no, uint64_t object_off,
       ceph::bufferlist&& data, IOContext io_context, int op_flags,
       int write_flags, std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, Context *completion);
+      const ZTracer::Trace &parent_trace, Context *completion,
+      std::optional<uint64_t> assert_tag = std::nullopt);
   static ObjectRequest* create_discard(
       ImageCtxT *ictx, uint64_t object_no, uint64_t object_off,
       uint64_t object_len, IOContext io_context, int discard_flags,
@@ -264,12 +265,14 @@ public:
       ImageCtxT *ictx, uint64_t object_no, uint64_t object_off,
       ceph::bufferlist&& data, IOContext io_context, int op_flags,
       int write_flags, std::optional<uint64_t> assert_version,
-      const ZTracer::Trace &parent_trace, Context *completion)
+      const ZTracer::Trace &parent_trace, Context *completion,
+      std::optional<uint64_t> assert_tag = std::nullopt)
     : AbstractObjectWriteRequest<ImageCtxT>(ictx, object_no, object_off,
                                             data.length(), io_context, "write",
                                             parent_trace, completion),
       m_write_data(std::move(data)), m_op_flags(op_flags),
-      m_write_flags(write_flags), m_assert_version(assert_version) {
+      m_write_flags(write_flags), m_assert_version(assert_version),
+      m_assert_tag(assert_tag) {
   }
 
   bool is_empty_write_op() const override {
@@ -289,6 +292,7 @@ private:
   int m_op_flags;
   int m_write_flags;
   std::optional<uint64_t> m_assert_version;
+  std::optional<uint64_t> m_assert_tag;
 };
 
 template <typename ImageCtxT = ImageCtx>

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -58,13 +58,15 @@ public:
 
   ObjectRequest(ImageCtxT *ictx, uint64_t objectno, IOContext io_context,
                 const char *trace_name, const ZTracer::Trace &parent_trace,
-                Context *completion);
+                Context *completion,
+                std::optional<uint64_t> assert_tag = std::nullopt);
   virtual ~ObjectRequest() {
     m_trace.event("finish");
   }
 
   static void add_write_hint(ImageCtxT& image_ctx,
                              neorados::WriteOp *wr);
+  void add_tag_check(neorados::Op *op);
 
   virtual void send() = 0;
 
@@ -83,6 +85,7 @@ protected:
   IOContext m_io_context;
   Context *m_completion;
   ZTracer::Trace m_trace;
+  std::optional<uint64_t> m_assert_tag;
 
   void async_finish(int r);
   void finish(int r);
@@ -157,7 +160,8 @@ public:
   AbstractObjectWriteRequest(
       ImageCtxT *ictx, uint64_t object_no, uint64_t object_off, uint64_t len,
       IOContext io_context, const char *trace_name,
-      const ZTracer::Trace &parent_trace, Context *completion);
+      const ZTracer::Trace &parent_trace, Context *completion,
+      std::optional<uint64_t> assert_tag = std::nullopt);
 
   virtual bool is_empty_write_op() const {
     return false;
@@ -269,10 +273,9 @@ public:
       std::optional<uint64_t> assert_tag = std::nullopt)
     : AbstractObjectWriteRequest<ImageCtxT>(ictx, object_no, object_off,
                                             data.length(), io_context, "write",
-                                            parent_trace, completion),
+                                            parent_trace, completion, assert_tag),
       m_write_data(std::move(data)), m_op_flags(op_flags),
-      m_write_flags(write_flags), m_assert_version(assert_version),
-      m_assert_tag(assert_tag) {
+      m_write_flags(write_flags), m_assert_version(assert_version) {
   }
 
   bool is_empty_write_op() const override {
@@ -292,7 +295,6 @@ private:
   int m_op_flags;
   int m_write_flags;
   std::optional<uint64_t> m_assert_version;
-  std::optional<uint64_t> m_assert_tag;
 };
 
 template <typename ImageCtxT = ImageCtx>

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2728,6 +2728,24 @@ namespace librbd {
     return 0;
   }
 
+  int Image::aio_write3(uint64_t off, size_t len, bufferlist& bl,
+        RBD::AioCompletion *c, int op_flags,
+        std::optional<uint64_t> assert_tag)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    tracepoint(librbd, aio_write2_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(),
+    ictx->read_only, off, len, bl.length() < len ? NULL : bl.c_str(), c->pc, op_flags);
+    if (bl.length() < len) {
+      tracepoint(librbd, aio_write_exit, -EINVAL);
+      return -EINVAL;
+    }
+    api::Io<>::aio_write(*ictx, get_aio_completion(c), off, len, bufferlist{bl},
+                         op_flags, true, assert_tag);
+
+    tracepoint(librbd, aio_write_exit, 0);
+    return 0;
+  }
+
   int Image::aio_read(uint64_t off, size_t len, bufferlist& bl,
 		      RBD::AioCompletion *c)
   {

--- a/src/tools/rbd_wnbd/CMakeLists.txt
+++ b/src/tools/rbd_wnbd/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(rbd-wnbd rbd_wnbd.cc wnbd_handler.cc wnbd_wmi.cc)
+add_executable(rbd-wnbd per_res.cc rbd_wnbd.cc wnbd_handler.cc wnbd_wmi.cc)
 set_target_properties(
     rbd-wnbd PROPERTIES COMPILE_FLAGS
     "-fpermissive -I${WNBD_INCLUDE_DIRS}")

--- a/src/tools/rbd_wnbd/per_res.cc
+++ b/src/tools/rbd_wnbd/per_res.cc
@@ -1,0 +1,1091 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Cloudbase Solutions
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd
+
+#include "per_res.h"
+
+#define _NTSCSI_USER_MODE_
+#include <rpc.h>
+#include <ddk/scsi.h>
+
+#ifndef RESERVATION_TYPE_WRITE_EXCLUSIVE_ALLREG
+#define RESERVATION_TYPE_WRITE_EXCLUSIVE_ALLREG 0x07
+#endif
+
+#ifndef RESERVATION_TYPE_EXCLUSIVE_ALLREG
+#define RESERVATION_TYPE_EXCLUSIVE_ALLREG 0x08
+#endif
+
+#ifndef SCSI_ADSENSE_UNRECOVERED_ERROR
+#define SCSI_ADSENSE_UNRECOVERED_ERROR 0x11
+#endif
+
+#include <boost/endian/conversion.hpp>
+
+#include "common/debug.h"
+#include "common/errno.h"
+#include "common/hostname.h"
+
+#include "global/global_context.h"
+
+#define WNBD_PR_INFO_XATTR_KEY      "pr_info.win32"
+
+#define RBD_HEADER_PREFIX "rbd_header."
+#define RBD_SUFFIX        ".rbd"
+
+// The number of PR OUT attempts, retrying when receiving EAGAIN errors caused
+// by concurrent PR updates.
+#define WNBD_PR_OUT_TRIES 5
+
+#define CLASS_NAME typeid(*this).name()
+
+// The scsi.h structure is missing a few SPC-3 fields so we'll define our own.
+typedef struct {
+  UCHAR ReservationKey[8];
+  UCHAR ServiceActionReservationKey[8];
+  UCHAR ScopeSpecificAddress[4];
+  UCHAR ActivatePersistThroughPowerLoss:1;
+  UCHAR Reserved1:1;
+  UCHAR AllTargetPorts:1;
+  UCHAR SpecifyInitiatorPorts:1;
+  UCHAR Reserved2:4;
+  UCHAR Reserved3;
+  UCHAR Obsolete[2];
+} RBD_PRO_PARAMETER_LIST, *PRBD_PRO_PARAMETER_LIST;
+static_assert(sizeof(RBD_PRO_PARAMETER_LIST) == sizeof(PRO_PARAMETER_LIST),
+              "Invalid structure size");
+
+std::string RbdPrInfo::get_header_obj_name()
+{
+  std::string image_id;
+  auto r = image.get_id(&image_id);
+  if (r < 0) {
+    // old format
+    std::string image_name;
+    r = image.get_name(&image_name);
+    // should always return 0
+    ceph_assert(!r);
+    return image_name + RBD_SUFFIX;
+  } else {
+    return RBD_HEADER_PREFIX + image_id;
+  }
+}
+
+std::string get_pr_initiator() {
+  // target_core_rbd includes the initiator name and target wwn in the i_t nexus
+  // buffer, which looks like this:
+  // iqn.1991-05.com.microsoft:ws2k22-node2.mydomain.local,i,0x3430303030313337,
+  //   iqn.2016-05.com.org:00002,t,0x1
+  //
+  // We don't receive much information about the initiator or target, however we
+  // know that there's at most one WNBD virtual SCSI adapter per host and that
+  // WNBD doesn't allow mapping the same image twice.
+  //
+  // We also know that we're only receiving SCSI Persistent Reservation
+  // commands emitted by this host, which is why the hostname will be the only
+  // i_t information that we'll use.
+  //
+  // Note that the Windows hostname might change after joining a domain, which
+  // might impact persistent reservations.
+  return ceph_get_hostname();
+}
+
+int RbdPrInfo::retrieve()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  auto object_name = get_header_obj_name();
+  auto r = rados_ctx.getxattr(object_name, WNBD_PR_INFO_XATTR_KEY, last_bl);
+  if (r < 0) {
+    if (r == -ENODATA) {
+      dout(5) << CLASS_NAME << "::" << __func__
+        << ": no pr xattr specified" << dendl;
+    } else {
+      derr << CLASS_NAME << "::" << __func__
+         << ": failed to retrieve PR info xattr"
+         << ": error: " << r << dendl;
+    }
+    return r;
+  }
+
+  bufferlist::const_iterator ci = last_bl.begin();
+
+  try {
+    decode(ci);
+  } catch (buffer::error& err) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": failed to decode PR xattr: "
+         << err.what() << dendl;
+    return -EINVAL;
+  }
+
+  dout(6) << CLASS_NAME << "::" << __func__ << ": retrieved: " << *this << dendl;
+  return 0;
+}
+
+int RbdPrInfo::retrieve_or_create()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  auto r = retrieve();
+  if (r == -ENODATA) {
+    r = create();
+  }
+
+  return r;
+}
+
+std::optional<per_reg> RbdPrInfo::get_reg(const std::string &initiator) const
+{
+  for (auto reg : regs) {
+    if (initiator == reg.initiator) {
+      return reg;
+    }
+  }
+  return {};
+}
+
+bool RbdPrInfo::all_registrants_access() const {
+  if (!res.has_value()) {
+    return false;
+  }
+  switch (res.value().type) {
+  case RESERVATION_TYPE_WRITE_EXCLUSIVE_ALLREG:
+  case RESERVATION_TYPE_EXCLUSIVE_ALLREG:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool RbdPrInfo::is_res_holder(
+  const std::string &initiator,
+  uint64_t res_key,
+  bool check_reg) const
+{
+  if (check_reg) {
+    auto existing_reg = get_reg(initiator);
+    if (!existing_reg || existing_reg->key != res_key) {
+      return false;
+    }
+  }
+
+  if (all_registrants_access()) {
+    return true;
+  }
+
+  return res.has_value() &&
+    res.value().initiator == initiator &&
+    res.value().key == res_key;
+}
+
+bool RbdPrInfo::has_reservation() const
+{
+  return res.has_value();
+}
+
+int RbdPrInfo::create()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  try {
+    encode(last_bl);
+  } catch (buffer::error& err) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": failed to encode PR xattr: "
+         << err.what() << dendl;
+    return -EINVAL;
+  }
+
+  auto object_name = get_header_obj_name();
+  auto r = rados_ctx.setxattr(object_name, WNBD_PR_INFO_XATTR_KEY, last_bl);
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+int RbdPrInfo::safe_replace()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  bufferlist bl;
+  try {
+    encode(bl);
+  } catch (buffer::error& err) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": failed to encode PR xattr: "
+         << err.what() << dendl;
+    return -EINVAL;
+  }
+
+  dout(5) << CLASS_NAME << "::" << __func__ << ": applying: " << *this << dendl;
+
+  librados::ObjectWriteOperation o;
+  o.cmpxattr(WNBD_PR_INFO_XATTR_KEY, CEPH_OSD_CMPXATTR_OP_EQ, last_bl);
+  o.setxattr(WNBD_PR_INFO_XATTR_KEY, bl);
+
+  auto object_name = get_header_obj_name();
+  auto r = rados_ctx.operate(object_name, &o);
+  if (r < 0) {
+    dout(5) << CLASS_NAME << "::" << __func__
+            << ": couldn't apply PR: " << *this
+            << ", error: " << r << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+std::ostream &operator<<(std::ostream &os, const RbdPrInfo &pr_info) {
+  os << std::hex
+     << "RbdPrInfo("
+     << "generation=0x" << pr_info.generation;
+
+  if (pr_info.has_reservation()) {
+    os << ", reservation=("
+       << "key=0x" << pr_info.res.value().key
+       << ", initiator=\"" << pr_info.res.value().initiator
+       << "\", type=0x" << (uint) pr_info.res.value().type
+       << ")";
+  } else {
+    os << ", reservation=None";
+  }
+
+  os << ", registrations=[";
+  if (!pr_info.regs.empty()) {
+    bool first = true;
+    for (auto reg: pr_info.regs) {
+      if (!first) {
+        os << ", ";
+      }
+      os << "("
+         << "key=0x" << reg.key
+         << ", initiator=\"" << reg.initiator
+         << "\")";
+      first = false;
+    }
+  }
+
+  os << "])";
+
+  return os;
+}
+
+int WnbdPerResInOperation::read_keys()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  auto pr_info = RbdPrInfo(rados_ctx, image);
+  int r = pr_info.retrieve_or_create();
+  if (r < 0) {
+    return r;
+  }
+
+  uint32_t generation_be = boost::endian::native_to_big(pr_info.generation);
+  out_buff.append(
+    reinterpret_cast<const char*>(&generation_be), sizeof(generation_be));
+
+  uint32_t additional_length_be = boost::endian::native_to_big(
+    uint32_t(pr_info.regs.size() * sizeof(uint64_t)));
+  out_buff.append(
+    reinterpret_cast<const char*>(&additional_length_be),
+    sizeof(additional_length_be));
+
+  for (auto reg : pr_info.regs) {
+    auto key_be = boost::endian::native_to_big(reg.key);
+    out_buff.append(
+      reinterpret_cast<const char*>(&key_be), sizeof(key_be));
+  }
+
+  return 0;
+}
+
+int WnbdPerResInOperation::read_reservations()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  auto pr_info = RbdPrInfo(rados_ctx, image);
+  int r = pr_info.retrieve_or_create();
+  if (r < 0) {
+    return r;
+  }
+
+  uint32_t additional_length = 0;
+  if (pr_info.has_reservation()) {
+    additional_length += sizeof(PRI_RESERVATION_DESCRIPTOR);
+  }
+
+  out_buff.push_back(
+    ceph::buffer::create(sizeof(PRI_RESERVATION_LIST) + additional_length));
+  auto o_res_list = (PPRI_RESERVATION_LIST) out_buff.c_str();
+
+  ((uint32_t*)o_res_list->Generation)[0] = boost::endian::native_to_big(
+    pr_info.generation);
+  ((uint32_t*)o_res_list->AdditionalLength)[0] = boost::endian::native_to_big(
+    additional_length);
+
+  if (pr_info.has_reservation()) {
+    PPRI_RESERVATION_DESCRIPTOR o_res = o_res_list->Reservations;
+
+    ((uint64_t*)o_res->ReservationKey)[0] = boost::endian::native_to_big(
+      pr_info.res.value().key);
+    o_res->Type = pr_info.res.value().type;
+    o_res->Scope = RESERVATION_SCOPE_LU;
+  }
+
+  return 0;
+}
+
+int WnbdPerResInOperation::execute()
+{
+  dout(5) << std::hex
+          << "WnbdPerResInOperation: "
+          << "action=0x" << (uint) service_action
+          << ", initiator=\"" << initiator << "\""
+          << ": start" << dendl;
+
+  int r = 0;
+  switch (service_action) {
+  case RESERVATION_ACTION_READ_KEYS:
+    r = read_keys();
+    break;
+  case RESERVATION_ACTION_READ_RESERVATIONS:
+    r = read_reservations();
+    break;
+  // TODO: consider implementing REPORT CAPABILITIES service action
+  default:
+    derr << "Unsupported Persistent Reservation IN service action: "
+         << std::hex << "0x" << (uint) service_action << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_ILLEGAL_COMMAND);
+    return -ENOTSUP;
+  }
+
+  if (r < 0 && !wnbd_status->ScsiStatus) {
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_MEDIUM_ERROR,
+      SCSI_ADSENSE_UNRECOVERED_ERROR);
+  }
+
+  return r;
+}
+
+int WnbdPerResOutOperation::parse_param_list()
+{
+  if (in_buff.length() < sizeof(RBD_PRO_PARAMETER_LIST)) {
+    derr << "Invalid PR OUT parameter list size: "
+         << in_buff.length() << " < "
+         << sizeof(RBD_PRO_PARAMETER_LIST) << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_PARAMETER_LIST_LENGTH);
+    return -EOVERFLOW;
+  }
+
+  PRBD_PRO_PARAMETER_LIST params = (PRBD_PRO_PARAMETER_LIST) in_buff.c_str();
+
+  res_key = boost::endian::big_to_native(
+    *reinterpret_cast<uint64_t*>(params->ReservationKey));
+  sv_act_res_key = boost::endian::big_to_native(
+    *reinterpret_cast<uint64_t*>(params->ServiceActionReservationKey));
+  scope_specif_addr = boost::endian::big_to_native(
+    *reinterpret_cast<uint64_t*>(params->ScopeSpecificAddress));
+  aptpl = params->ActivatePersistThroughPowerLoss;
+  all_tg_pt = params->AllTargetPorts;
+  spec_i_pt = params->SpecifyInitiatorPorts;
+  return 0;
+}
+
+int WnbdPerResOutOperation::register_key(bool ignore_existing)
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  if (all_tg_pt) {
+    derr << "unsupported PR flag: all_tg_pt" << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_INVALID_CDB);
+    return -EINVAL;
+  }
+
+  if (spec_i_pt) {
+    derr << "unsupported PR flag: spec_i_pt" << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_INVALID_CDB);
+    return -EINVAL;
+  }
+
+  auto pr_info = RbdPrInfo(rados_ctx, image);
+  int r = pr_info.retrieve_or_create();
+  if (r < 0) {
+    return r;
+  }
+
+  per_reg* existing_reg = nullptr;
+  for (auto& reg : pr_info.regs) {
+    if (initiator == reg.initiator) {
+      existing_reg = &reg;
+    }
+  }
+
+  if (!existing_reg) {
+    if (!ignore_existing && (res_key != 0)) {
+      derr << "Reservation conflict. "
+           << "New initiator, yet an old key was provided."
+           << dendl;
+      wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+      return -EEXIST;
+    }
+    if (sv_act_res_key == 0) {
+      // delete no-op
+      dout(20) << CLASS_NAME << "::" << __func__
+               << ": was requested to delete registration but the initiator "
+               << "is unregistered, no-op" << dendl;
+      return 0;
+    }
+  } else {
+    // found existing registration
+    if (!ignore_existing && (res_key != existing_reg->key)) {
+      derr << "Reservation conflict. "
+           << "Existing initiator, old key mismatch: "
+           << std::hex << "0x" << res_key << " != "
+           << "0x" << existing_reg->key << dendl;
+      wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+      return -EEXIST;
+    }
+
+    if (sv_act_res_key == 0) {
+      dout(20) << CLASS_NAME << "::" << __func__
+               << ": removing registration" << dendl;
+      bool reg_found = false;
+      remove_own_reg(pr_info, reg_found);
+
+      pr_info.generation++;
+      return pr_info.safe_replace();
+    }
+  }
+
+  if (!existing_reg) {
+    dout(20) << CLASS_NAME << "::" << __func__
+             << ": adding new registration" << dendl;
+    per_reg new_reg = {
+      .key = sv_act_res_key,
+      .initiator = initiator,
+    };
+    pr_info.regs.push_back(new_reg);
+  } else {
+    dout(20) << CLASS_NAME << "::" << __func__
+             << ": changing registration key" << dendl;
+    existing_reg->key = sv_act_res_key;
+
+    if (pr_info.has_reservation() &&
+        initiator == pr_info.res.value().initiator) {
+      pr_info.res.value().key = sv_act_res_key;
+    }
+  }
+
+  pr_info.generation++;
+  return pr_info.safe_replace();
+}
+
+void WnbdPerResOutOperation::remove_own_reg(
+  RbdPrInfo& pr_info,
+  bool& found)
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  for (auto it = pr_info.regs.begin(); it != pr_info.regs.end();) {
+    if (initiator == it->initiator) {
+      dout(20) << CLASS_NAME << "::" << __func__ << ": removing registration: "
+               << std::hex
+               << "initiator: " << initiator
+               << ", key: 0x" << it->key << dendl;
+      if (!pr_info.all_registrants_access() &&
+          pr_info.is_res_holder(initiator, res_key, false)) {
+        dout(5) << CLASS_NAME << "::" << __func__
+                << std::hex
+                << "cleaning up reservation while removing registration"
+                << ", type: 0x" << (uint) pr_info.res.value().type
+                << dendl;
+        pr_info.res.reset();
+      }
+
+      found = true;
+      it = pr_info.regs.erase(it);
+    } else {
+      it++;
+    }
+  }
+}
+
+void WnbdPerResOutOperation::preempt_reg(
+  RbdPrInfo& pr_info,
+  bool& found)
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  for (auto it = pr_info.regs.begin(); it != pr_info.regs.end();) {
+    if (initiator == it->initiator) {
+      it++;
+      continue;
+    }
+
+    if (sv_act_res_key && (it->key != sv_act_res_key)) {
+      it++;
+      continue;
+    }
+
+    found = true;
+    it = pr_info.regs.erase(it);
+    dout(5) << CLASS_NAME << "::" << __func__
+            << ": preempted registration" << dendl;
+  }
+  if (!found) {
+    dout(5) << CLASS_NAME << "::" << __func__
+            << ": couldn't find registration to preempt" << dendl;
+  }
+}
+
+void WnbdPerResOutOperation::do_reserve(RbdPrInfo& pr_info)
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  per_res reservation = {
+    .key = res_key,
+    .initiator = initiator,
+    .type = type,
+  };
+  pr_info.res.emplace(reservation);
+}
+
+int WnbdPerResOutOperation::reserve()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  auto pr_info = RbdPrInfo(rados_ctx, image);
+  int r = pr_info.retrieve_or_create();
+  if (r < 0) {
+    return r;
+  }
+
+  auto existing_reg = pr_info.get_reg(initiator);
+
+  if (!existing_reg) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": reserve without registration" << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_LUN_COMMUNICATION);
+    return -EINVAL;
+  }
+
+  if (res_key != existing_reg->key) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": PR key mismatch: "
+         << std::hex << "0x" << res_key << " != "
+         << "0x" << existing_reg->key << dendl;
+    wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+    return -EEXIST;
+  }
+
+  if (pr_info.has_reservation()) {
+    if (!pr_info.is_res_holder(initiator, res_key, false)) {
+      derr << CLASS_NAME << "::" << __func__
+         << ": unable to acquire reservation, already held by "
+         << pr_info.res.value().initiator
+         << ". registration type: 0x" << std::hex << pr_info.res.value().type
+         << dendl;
+      wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+      return -EEXIST;
+    }
+
+    if (pr_info.res.value().type != type) {
+      derr << CLASS_NAME << "::" << __func__
+         << ": reservation request with mismatching type: "
+         << std::hex
+         << "0x" << (uint) pr_info.res.value().type << " != "
+         << "0x" << (uint) type << dendl;
+      wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+      return -EEXIST;
+    }
+
+    dout(20) << CLASS_NAME << "::" << __func__
+             << ": found matching reservation, no-op" << dendl;
+    return 0;
+  }
+
+  do_reserve(pr_info);
+  return pr_info.safe_replace();
+}
+
+int WnbdPerResOutOperation::release()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  auto pr_info = RbdPrInfo(rados_ctx, image);
+  int r = pr_info.retrieve_or_create();
+  if (r < 0) {
+    return r;
+  }
+
+  if (!pr_info.has_reservation()) {
+    dout(20) << CLASS_NAME << "::" << __func__
+             << ": no reservation, no-op" << dendl;
+    return 0;
+  }
+
+  auto existing_reg = pr_info.get_reg(initiator);
+
+  if (!existing_reg) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": release without registration" << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_LUN_COMMUNICATION);
+    return -EINVAL;
+  }
+
+  if (!pr_info.is_res_holder(initiator, res_key, false)) {
+    derr << CLASS_NAME << "::" << __func__
+       << ": not a registration holder, no-op "
+       << dendl;
+    return 0;
+  }
+
+  if (res_key != existing_reg->key) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": PR key mismatch: "
+         << std::hex << "0x" << res_key << " != "
+         << "0x" << existing_reg->key << dendl;
+    wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+    return -EEXIST;
+  }
+
+  if (pr_info.res.value().type != type) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": release request with mismatching type: "
+         << std::hex
+         << "0x" << (uint) pr_info.res.value().type << " != "
+         << "0x" << (uint) type << dendl;
+    wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+    return -EEXIST;
+  }
+
+  // TODO: notify other reservation holders about the released reservation
+  // using SCSI SENSE.
+  dout(5) << CLASS_NAME << "::" << __func__
+          << ": releasing reservation" << dendl;
+  pr_info.res.reset();
+  return pr_info.safe_replace();
+}
+
+int WnbdPerResOutOperation::clear()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  auto pr_info = RbdPrInfo(rados_ctx, image);
+  int r = pr_info.retrieve_or_create();
+  if (r < 0) {
+    return r;
+  }
+
+  auto existing_reg = pr_info.get_reg(initiator);
+
+  if (!existing_reg) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": release without registration" << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_LUN_COMMUNICATION);
+    return -EINVAL;
+  }
+
+  if (res_key != existing_reg->key) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": PR key mismatch: "
+         << std::hex << "0x" << res_key << " != "
+         << "0x" << existing_reg->key << dendl;
+    wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+    return -EEXIST;
+  }
+
+  dout(5) << CLASS_NAME << "::" << __func__
+          << ": clearing reservation and registrations" << dendl;
+  // TODO: notify other initiators about the preempted reservations
+  // using SCSI SENSE.
+  pr_info.regs.clear();
+  pr_info.res.reset();
+  pr_info.generation++;
+  return pr_info.safe_replace();
+}
+
+// SCSI SPC-3 compliant (5.6.10.4 Preempting)
+int WnbdPerResOutOperation::preempt()
+{
+  dout(20) << CLASS_NAME << "::" << __func__ << ": start" << dendl;
+
+  auto pr_info = RbdPrInfo(rados_ctx, image);
+  int r = pr_info.retrieve_or_create();
+  if (r < 0) {
+    return r;
+  }
+
+  auto existing_reg = pr_info.get_reg(initiator);
+
+  if (!existing_reg) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": release without registration" << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_LUN_COMMUNICATION);
+    return -EINVAL;
+  }
+
+  if (res_key != existing_reg->key) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": PR key mismatch: "
+         << std::hex << "0x" << res_key << " != "
+         << "0x" << existing_reg->key << dendl;
+    wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+    return -EEXIST;
+  }
+
+  bool regs_found = false;
+
+  if (!pr_info.has_reservation()) {
+    dout(20) << CLASS_NAME << "::" << __func__
+             << ": preempt requested, no reservation found" << dendl;
+    if (!sv_act_res_key) {
+      derr << CLASS_NAME << "::" << __func__
+           << ": reservation conflict"
+           << ": no existing reservation and no new key specified"
+           << dendl;
+      WnbdSetSense(
+        wnbd_status,
+        SCSI_SENSE_ILLEGAL_REQUEST,
+        SCSI_ADSENSE_INVALID_FIELD_PARAMETER_LIST);
+      return -EINVAL;
+    }
+
+    preempt_reg(pr_info, regs_found);
+    if (!regs_found) {
+      derr << CLASS_NAME << "::" << __func__
+           << ": reservation conflict"
+           << ": couldn't find the registration to preempt"
+           << dendl;
+      wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+      return -EEXIST;
+    }
+
+    goto commit;
+  }
+
+  if (pr_info.all_registrants_access()) {
+    dout(20) << CLASS_NAME << "::" << __func__
+             << ": reservation applies to all registrants"
+             << dendl;
+    preempt_reg(pr_info, regs_found);
+    if (!regs_found) {
+      derr << CLASS_NAME << "::" << __func__
+           << ": reservation conflict"
+           << ": couldn't find the registration to preempt"
+           << dendl;
+      wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+      return -EEXIST;
+    }
+
+    if (!sv_act_res_key) {
+      dout(5) << CLASS_NAME << "::" << __func__
+              << ": replacing reservation"
+              << dendl;
+      do_reserve(pr_info);
+    }
+    goto commit;
+  }
+
+  if (pr_info.res.value().key != sv_act_res_key) {
+    if (!sv_act_res_key) {
+      derr << CLASS_NAME << "::" << __func__
+           << ": reservation conflict"
+           << ": didn't specify which reservation to preempt, "
+           << " the existing reservation doesn't apply to all registrants"
+           << dendl;
+      WnbdSetSense(
+        wnbd_status,
+        SCSI_SENSE_ILLEGAL_REQUEST,
+        SCSI_ADSENSE_INVALID_FIELD_PARAMETER_LIST);
+      return -EINVAL;
+    }
+
+    dout(5) << CLASS_NAME << "::" << __func__
+            << ": the existing reservation doesn't match the specified key "
+            << " and it doesn't apply to all registrants. The reservation "
+            << " will be left in place while the specified registration "
+            << " will be preempted."
+            << dendl;
+
+    preempt_reg(pr_info, regs_found);
+    if (!regs_found) {
+      derr << CLASS_NAME << "::" << __func__
+           << ": reservation conflict"
+           << ": couldn't find the registration to preempt"
+           << dendl;
+      wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+      return -EEXIST;
+    }
+    goto commit;
+  }
+
+  preempt_reg(pr_info, regs_found);
+  if (!regs_found && initiator != pr_info.res.value().initiator) {
+    derr << CLASS_NAME << "::" << __func__
+         << ": reservation conflict"
+         << ": couldn't find the registration to preempt"
+         << dendl;
+    wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+    return -EEXIST;
+  }
+
+  dout(5) << CLASS_NAME << "::" << __func__
+          << ": replacing reservation"
+          << dendl;
+  do_reserve(pr_info);
+
+commit:
+  // TODO: notify other initiators about the preempted reservation
+  // using SCSI SENSE.
+  pr_info.generation++;
+  return pr_info.safe_replace();
+}
+
+int WnbdPerResOutOperation::do_execute()
+{
+  int r = parse_param_list();
+  if (r != 0) {
+    return r;
+  }
+
+  dout(5) << std::hex
+          << "WnbdPerResOutOperation: "
+          << "action=0x" << (uint) service_action
+          << ", scope=0x" << (uint) scope
+          << ", type=0x" << (uint) type
+          << ", initiator=\"" << initiator << "\""
+          << ", res_key=0x" << res_key
+          << ", sv_act_res_key=0x" << sv_act_res_key
+          << ", scope_specif_addr=0x" << scope_specif_addr
+          << ": start" << dendl;
+
+  if (scope != RESERVATION_SCOPE_LU) {
+    derr << CLASS_NAME << "::" << __func__
+         << std::hex
+         << ": unsupported scope: 0x" << (uint) scope << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_LUN_COMMUNICATION);
+    return -EINVAL;
+  }
+
+  switch (service_action) {
+  case RESERVATION_ACTION_REGISTER:
+    return register_key(false);
+  case RESERVATION_ACTION_REGISTER_IGNORE_EXISTING:
+    return register_key(true);
+  case RESERVATION_ACTION_RESERVE:
+    return reserve();
+  case RESERVATION_ACTION_RELEASE:
+    return release();
+  case RESERVATION_ACTION_CLEAR:
+    return clear();
+  case RESERVATION_ACTION_PREEMPT:
+    return preempt();
+  default:
+    dout(5) << "Unsupported Persistent Reservation OUT service action: "
+            << std::hex << "0x" << service_action << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_ILLEGAL_COMMAND);
+    return -ENOTSUP;
+  }
+  return 0;
+}
+
+int WnbdPerResOutOperation::execute()
+{
+  int r = -EAGAIN;
+  for (int attempt=0;
+       r == -EAGAIN && attempt < WNBD_PR_OUT_TRIES;
+       attempt++){
+    r = do_execute();
+
+    if (r == -EAGAIN && attempt < WNBD_PR_OUT_TRIES) {
+      dout(5) << "encountered conflict while trying to update "
+              << "persistent reservations. Tries left: "
+              << WNBD_PR_OUT_TRIES - attempt - 1
+              << dendl;
+      // clear wnbd status before retrying
+      *wnbd_status = {0};
+    }
+  }
+
+  if (r < 0 && !wnbd_status->ScsiStatus) {
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_MEDIUM_ERROR,
+      SCSI_ADSENSE_UNRECOVERED_ERROR);
+  }
+
+  return r;
+}
+
+int check_pr_conflict(
+  librbd::IoCtx& rados_ctx,
+  librbd::Image& image,
+  WnbdRequestType req_type,
+  std::string &initiator,
+  PWNBD_STATUS wnbd_status)
+{
+  dout(20) << __func__ << ": start" << dendl;
+
+  auto pr_info = RbdPrInfo(rados_ctx, image);
+  int r = pr_info.retrieve();
+  if (r == -ENODATA) {
+    dout(20) << __func__ << ": no pr data" << dendl;
+    return 0;
+  }
+
+  if (r < 0) {
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_MEDIUM_ERROR,
+      SCSI_ADSENSE_UNRECOVERED_ERROR);
+    return r;
+  }
+
+  bool is_write = false;
+  switch (req_type) {
+  case WnbdReqTypePersistResIn:
+  case WnbdReqTypePersistResOut:
+    // PR command conflicts are checked separately, let's avoid
+    // duplication
+    return 0;
+  case WnbdReqTypeRead:
+    break;
+  case WnbdReqTypeWrite:
+  case WnbdReqTypeFlush:
+  case WnbdReqTypeUnmap:
+    // we're treating flush and unmap the same way as writes
+    is_write = true;
+    break;
+  default:
+    derr << __func__
+      << ": unsupported wnbd request type: 0x"
+      << std::hex << req_type << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_LUN_COMMUNICATION);
+    return -EINVAL;
+  }
+
+  if (!pr_info.has_reservation()) {
+    dout(20) << __func__
+      << ": no persistent reservation" << dendl;
+    return 0;
+  }
+
+  if (initiator == pr_info.res.value().initiator) {
+    dout(20) << __func__
+      << ": explicit reservation holder" << dendl;
+    return 0;
+  }
+
+  auto reg = pr_info.get_reg(initiator);
+  bool has_reg = reg.has_value();
+
+  bool reg_nexuses = false;
+  bool write_exclusive = false;
+
+  switch (pr_info.res.value().type) {
+  case RESERVATION_TYPE_WRITE_EXCLUSIVE:
+    write_exclusive = true;
+  case RESERVATION_TYPE_EXCLUSIVE:
+    break;
+  case RESERVATION_TYPE_WRITE_EXCLUSIVE_REGISTRANTS:
+  case RESERVATION_TYPE_WRITE_EXCLUSIVE_ALLREG:
+    write_exclusive = true;
+  case RESERVATION_TYPE_EXCLUSIVE_REGISTRANTS:
+  case RESERVATION_TYPE_EXCLUSIVE_ALLREG:
+    reg_nexuses = true;
+    break;
+  default:
+    derr << __func__
+      << ": unsupported reservation type: 0x"
+      << std::hex << pr_info.res.value().type
+      << dendl;
+    WnbdSetSense(
+      wnbd_status,
+      SCSI_SENSE_ILLEGAL_REQUEST,
+      SCSI_ADSENSE_LUN_COMMUNICATION);
+    return -EINVAL;
+  }
+
+  if (!is_write) {
+    if (write_exclusive) {
+      dout(20) << __func__
+        << ": allowing non-write operation with write exclusive pr"
+        << dendl;
+      return 0;
+    }
+  }
+
+  if (reg_nexuses) {
+    if (has_reg) {
+      dout(20) << __func__
+        << ": allowing operation"
+        << ": reg present, RR rsv"
+        << dendl;
+      return 0;
+    } else {
+      dout(10) << __func__
+        << ": reservation conflict"
+        << ": no reg, exclusive rsv"
+        << dendl;
+    }
+  } else {
+    dout(10) << __func__
+      << ": reservation conflict"
+      << ": exclusive rsv, not rsv owner"
+      << dendl;
+  }
+
+  // conflict by default
+  wnbd_status->ScsiStatus = SCSISTAT_RESERVATION_CONFLICT;
+  return -EINVAL;
+}

--- a/src/tools/rbd_wnbd/per_res.h
+++ b/src/tools/rbd_wnbd/per_res.h
@@ -1,0 +1,242 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Cloudbase Solutions
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef WNBD_PER_RES_H
+#define WNBD_PER_RES_H
+
+#include <wnbd.h>
+
+#include "include/encoding.h"
+#include "include/rbd/librbd.hpp"
+
+std::string get_pr_initiator();
+
+// persistent registration info
+struct per_reg {
+  uint64_t key;
+  std::string initiator;
+
+  void encode(bufferlist &bl) const
+  {
+    using ceph::encode;
+    ENCODE_START(1, 1, bl);
+    encode(key, bl);
+    encode(initiator, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator &bl)
+  {
+    using ceph::decode;
+    DECODE_START(1, bl);
+    decode(key, bl);
+    decode(initiator, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(per_reg)
+
+// persistent reservation
+struct per_res {
+  uint64_t key;
+  std::string initiator;
+  uint8_t type;
+
+  void encode(bufferlist &bl) const
+  {
+    using ceph::encode;
+    ENCODE_START(1, 1, bl);
+    encode(key, bl);
+    encode(initiator, bl);
+    encode(type, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator &bl)
+  {
+    using ceph::decode;
+    DECODE_START(1, bl);
+    decode(key, bl);
+    decode(initiator, bl);
+    decode(type, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(per_res)
+
+// persistent registration and reservation info
+class RbdPrInfo
+{
+private:
+  librados::IoCtx &rados_ctx;
+  librbd::Image &image;
+
+  // The last retrieved state, used for "compare and write"
+  // operations.
+  bufferlist last_bl;
+
+  std::string get_header_obj_name();
+public:
+  uint32_t generation;
+  // persistent registrations
+  std::vector<per_reg> regs;
+  // persistent reservation
+  std::optional<per_res> res;
+
+  void encode(bufferlist &bl) const
+  {
+    using ceph::encode;
+    ENCODE_START(1, 1, bl);
+    encode(generation, bl);
+    encode(regs, bl);
+    encode(res, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator &bl)
+  {
+    using ceph::decode;
+    DECODE_START(1, bl);
+    decode(generation, bl);
+    decode(regs, bl);
+    decode(res, bl);
+    DECODE_FINISH(bl);
+  }
+
+  int create();
+  int retrieve();
+  int retrieve_or_create();
+  // Performs an atomic "compare and write" operation, checking the last known
+  // state of the xattr data, which must be explicitly retrieved first.
+  int safe_replace();
+
+  // get registration
+  std::optional<per_reg> get_reg(const std::string &initiator) const;
+  bool is_res_holder(
+    const std::string &initiator,
+    uint64_t res_key,
+    bool check_reg) const;
+  bool has_reservation() const;
+  bool all_registrants_access() const;
+
+  friend std::ostream &operator<<(std::ostream &os, const RbdPrInfo &pr_info);
+
+  RbdPrInfo(librbd::IoCtx& _rados_ctx,
+            librbd::Image& _image)
+    : rados_ctx(_rados_ctx)
+    , image(_image)
+    , generation(0)
+  {
+  }
+};
+
+std::ostream &operator<<(std::ostream &os, const RbdPrInfo &pr_info);
+
+// WNBD PERSISTENT RESERVATION IN operation
+class WnbdPerResInOperation
+{
+private:
+  librados::IoCtx &rados_ctx;
+  librbd::Image &image;
+  std::string initiator;
+  uint8_t service_action;
+
+  bufferlist& out_buff;
+  PWNBD_STATUS wnbd_status;
+
+  int read_keys();
+  int read_reservations();
+
+public:
+  WnbdPerResInOperation(librbd::IoCtx& _rados_ctx,
+                        librbd::Image& _image,
+                        std::string& _initiator,
+                        uint16_t _service_action,
+                        bufferlist& _out_buff,
+                        PWNBD_STATUS _wnbd_status)
+    : rados_ctx(_rados_ctx)
+    , image(_image)
+    , initiator(_initiator)
+    , service_action(_service_action)
+    , out_buff(_out_buff)
+    , wnbd_status(_wnbd_status)
+  {
+  }
+
+  int execute();
+};
+
+// WNBD PERSISTENT RESERVATION OUT operation
+class WnbdPerResOutOperation
+{
+private:
+  librados::IoCtx &rados_ctx;
+  librbd::Image &image;
+  std::string initiator;
+  uint8_t service_action;
+  uint8_t scope;
+  uint8_t type;
+
+  bufferlist& in_buff;
+  PWNBD_STATUS wnbd_status;
+
+  // common parameter list fields
+  uint64_t res_key;
+  uint64_t sv_act_res_key;
+  uint32_t scope_specif_addr;
+  bool aptpl;
+  bool all_tg_pt;
+  bool spec_i_pt;
+
+  int parse_param_list();
+  int do_execute();
+
+  int register_key(bool ignore_existing);
+  void remove_own_reg(RbdPrInfo& pr_info, bool& found);
+  void preempt_reg(RbdPrInfo& pr_info, bool& found);
+  int reserve();
+  void do_reserve(RbdPrInfo& pr_info);
+  int release();
+  int clear();
+  int preempt();
+
+public:
+  WnbdPerResOutOperation(librbd::IoCtx& _rados_ctx,
+                        librbd::Image& _image,
+                        std::string& _initiator,
+                        uint8_t _service_action,
+                        uint8_t _scope,
+                        uint8_t _type,
+                        bufferlist& _in_buff,
+                        PWNBD_STATUS _wnbd_status)
+    : rados_ctx(_rados_ctx)
+    , image(_image)
+    , initiator(_initiator)
+    , service_action(_service_action)
+    , scope(_scope)
+    , type(_type)
+    , in_buff(_in_buff)
+    , wnbd_status(_wnbd_status)
+  {
+  }
+
+  int execute();
+};
+
+int check_pr_conflict(
+  librbd::IoCtx& rados_ctx,
+  librbd::Image& image,
+  WnbdRequestType req_type,
+  std::string& initiator,
+  PWNBD_STATUS wnbd_status);
+
+#endif // WNBD_PER_RES_H

--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -1071,6 +1071,7 @@ Map options:
   --device <device path>  Optional mapping unique identifier
   --exclusive             Forbid writes by other clients
   --read-only             Map read-only
+  --enable-pr             Enable persistent reservations (EXPERIMENTAL)
   --non-persistent        Do not recreate the mapping when the Ceph service
                           restarts. By default, mappings are persistent
   --io-req-workers        The number of workers that dispatch IO requests.
@@ -1280,11 +1281,18 @@ static int do_map(Config *cfg)
   if (r < 0)
     goto close_ret;
 
-  handler = new WnbdHandler(image, cfg->devpath, cfg->snapname,
+  if (cfg->enable_pr) {
+    dout(0) << "warning: persistent reservation support is experimental"
+      << dendl;
+  }
+
+  handler = new WnbdHandler(io_ctx,
+                            image, cfg->devpath, cfg->snapname,
                             info.size / RBD_WNBD_BLKSIZE,
                             RBD_WNBD_BLKSIZE,
                             !cfg->snapname.empty() || cfg->readonly,
                             g_conf().get_val<bool>("rbd_cache"),
+                            cfg->enable_pr,
                             cfg->io_req_workers,
                             cfg->io_reply_workers);
   r = handler->start();
@@ -1613,6 +1621,8 @@ static int parse_args(std::vector<const char*>& args,
       cfg->readonly = true;
     } else if (ceph_argparse_flag(args, i, "--exclusive", (char *)NULL)) {
       cfg->exclusive = true;
+    } else if (ceph_argparse_flag(args, i, "--enable-pr", (char *)NULL)) {
+      cfg->enable_pr = true;
     } else if (ceph_argparse_flag(args, i, "--non-persistent", (char *)NULL)) {
       cfg->persistent = false;
     } else if (ceph_argparse_flag(args, i, "--pretty-format", (char *)NULL)) {

--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -1280,7 +1280,7 @@ static int do_map(Config *cfg)
   if (r < 0)
     goto close_ret;
 
-  handler = new WnbdHandler(image, cfg->devpath,
+  handler = new WnbdHandler(image, cfg->devpath, cfg->snapname,
                             info.size / RBD_WNBD_BLKSIZE,
                             RBD_WNBD_BLKSIZE,
                             !cfg->snapname.empty() || cfg->readonly,

--- a/src/tools/rbd_wnbd/rbd_wnbd.h
+++ b/src/tools/rbd_wnbd/rbd_wnbd.h
@@ -48,6 +48,8 @@ ceph::mutex shutdown_lock = ceph::make_mutex("RbdWnbd::ShutdownLock");
 struct Config {
   bool exclusive = false;
   bool readonly = false;
+  // Enable persistent reservations;
+  bool enable_pr = false;
 
   std::string parent_pipe;
 

--- a/src/tools/rbd_wnbd/wnbd_handler.cc
+++ b/src/tools/rbd_wnbd/wnbd_handler.cc
@@ -441,7 +441,8 @@ int WnbdHandler::start()
 
   wnbd_props.NaaIdentifier = naa_id;
 
-  err = WnbdCreate(&wnbd_props, &RbdWnbdInterface, this, &wnbd_disk);
+  err = WnbdCreate(&wnbd_props, (const PWNBD_INTERFACE) &RbdWnbdInterface,
+                   this, &wnbd_disk);
   if (err)
     goto exit;
 

--- a/src/tools/rbd_wnbd/wnbd_handler.cc
+++ b/src/tools/rbd_wnbd/wnbd_handler.cc
@@ -21,6 +21,7 @@
 
 #include <boost/thread/tss.hpp>
 
+#include "common/ceph_crypto.h"
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
@@ -372,7 +373,7 @@ void WnbdHandler::LogMessage(
 int WnbdHandler::resize(uint64_t new_size)
 {
   int err = 0;
-  
+
   uint64_t new_block_count = new_size / block_size;
 
   dout(5) << "Resizing disk. Block size: " << block_size
@@ -389,6 +390,29 @@ int WnbdHandler::resize(uint64_t new_size)
   dout(5) << "Successfully resized disk to: " << new_block_count << " blocks"
           << dendl;
   return 0;
+}
+
+void WnbdHandler::generate_naa_id(WNBD_NAA_ID &naa_id)
+{
+  int64_t pool_id;
+  uint64_t snap_id;
+  std::string img_id;
+
+  pool_id = image.get_data_pool_id();
+  image.snap_get_id(snap_name, &snap_id);
+  image.get_id(&img_id);
+
+  bufferlist bl;
+  bl.append((char*)(&pool_id), sizeof(pool_id));
+  bl.append((char*)(&snap_id), sizeof(snap_id));
+  bl.append(img_id.c_str(), img_id.size());
+
+  md5_digest_t md5 = ceph::crypto::digest<ceph::crypto::MD5>(bl);
+
+  // NAA IEEE Registered Extended identifier format
+  naa_id.data[0] = 0x60;
+
+  memcpy(naa_id.data+1, md5.v, sizeof(naa_id.data)-1);
 }
 
 int WnbdHandler::start()
@@ -410,6 +434,12 @@ int WnbdHandler::start()
     wnbd_props.Flags.FUASupported = 1;
     wnbd_props.Flags.FlushSupported = 1;
   }
+  wnbd_props.Flags.NaaIdSpecified = 1;
+
+  WNBD_NAA_ID naa_id = {0};
+  generate_naa_id(naa_id);
+
+  wnbd_props.NaaIdentifier = naa_id;
 
   err = WnbdCreate(&wnbd_props, &RbdWnbdInterface, this, &wnbd_disk);
   if (err)

--- a/src/tools/rbd_wnbd/wnbd_handler.cc
+++ b/src/tools/rbd_wnbd/wnbd_handler.cc
@@ -14,6 +14,7 @@
 #define dout_subsys ceph_subsys_rbd
 
 #include "wnbd_handler.h"
+#include "per_res.h"
 
 #define _NTSCSI_USER_MODE_
 #include <rpc.h>
@@ -242,6 +243,31 @@ void WnbdHandler::IOContext::set_sense(uint8_t sense_key, uint8_t asc)
   WnbdSetSense(&wnbd_status, sense_key, asc);
 }
 
+int WnbdHandler::IOContext::check_rsv_conflict()
+{
+  ceph_assert(handler);
+
+  if (handler->enable_pr) {
+    int r = check_pr_conflict(
+      handler->rados_ctx,
+      handler->image,
+      req_type,
+      handler->pr_initiator,
+      &wnbd_status);
+    if (r < 0) {
+      dout(5) << *this << "persistent reservation conflict" << dendl;
+      // send_io_response disposes *this, avoid using it after this call
+      handler->send_io_response(this);
+      return r;
+    }
+  } else {
+    dout(20) << *this << ": persistent reservations disabled" << dendl;
+  }
+
+  return 0;
+}
+
+
 void WnbdHandler::Read(
   PWNBD_DISK Disk,
   UINT64 RequestHandle,
@@ -267,6 +293,30 @@ void WnbdHandler::Read(
   }
 
   dout(20) << *ctx << ": start" << dendl;
+
+  // TODO: just like target_core_rbd, we're checking for persistent reservation
+  // conflicts before each IO request. There are some consequences in terms of:
+  //
+  // * performance - additional round-trip for every IO request
+  //
+  // * data consistency - if the node temporarily loses connection, gets
+  // preempted and then recovers network connectivity, queued IO operations may
+  // be submitted, ignoring the current reservations. This can be mitigated
+  // by carefully configuring timeouts. In the future, we may consider using
+  // Ceph blocklists.
+  //
+  // Eventually, we might be able to emulate persistent reservations using
+  // rbd locks and maybe ceph blocklists, however there are few key limitations
+  // that make it unfeasible: rbd locks are advisory, shared locks can't be
+  // preempted and blocklists apply to the entire host, not just a single
+  // client. Another option might be to use compound operations such as
+  // "compare and write", however the rbd api isn't as flexible as librados.
+  //
+  // Worth mentioning that PR PREEMPT is used by MS FC even for graceful CSV
+  // ownership changes (moves), not just in case of failures.
+  if (ctx->check_rsv_conflict()) {
+    return;
+  }
 
   librbd::RBD::AioCompletion *c = new librbd::RBD::AioCompletion(ctx, aio_callback);
   handler->image.aio_read2(ctx->req_from, ctx->req_size, ctx->data, c, op_flags);
@@ -302,6 +352,10 @@ void WnbdHandler::Write(
 
   dout(20) << *ctx << ": start" << dendl;
 
+  if (ctx->check_rsv_conflict()) {
+    return;
+  }
+
   librbd::RBD::AioCompletion *c = new librbd::RBD::AioCompletion(ctx, aio_callback);
   handler->image.aio_write2(ctx->req_from, ctx->req_size, ctx->data, c, op_flags);
 
@@ -325,6 +379,13 @@ void WnbdHandler::Flush(
   ctx->req_from = BlockAddress * handler->block_size;
 
   dout(20) << *ctx << ": start" << dendl;
+
+  // TODO: should we enforce that rbd caching is disabled when persistent
+  // reservations are enabled? in that case, we wouldn't receive flush
+  // requests.
+  if (ctx->check_rsv_conflict()) {
+    return;
+  }
 
   librbd::RBD::AioCompletion *c = new librbd::RBD::AioCompletion(ctx, aio_callback);
   handler->image.aio_flush(c);
@@ -351,8 +412,90 @@ void WnbdHandler::Unmap(
 
   dout(20) << *ctx << ": start" << dendl;
 
+  if (ctx->check_rsv_conflict()) {
+    return;
+  }
+
   librbd::RBD::AioCompletion *c = new librbd::RBD::AioCompletion(ctx, aio_callback);
   handler->image.aio_discard(ctx->req_from, ctx->req_size, c);
+
+  dout(20) << *ctx << ": submitted" << dendl;
+}
+
+void WnbdHandler::PersistResIn(
+  PWNBD_DISK Disk,
+  UINT64 RequestHandle,
+  UINT8 ServiceAction)
+{
+  WnbdHandler* handler = nullptr;
+  ceph_assert(!WnbdGetUserContext(Disk, (PVOID*)&handler));
+
+  WnbdHandler::IOContext* ctx = new WnbdHandler::IOContext();
+  ctx->handler = handler;
+  ctx->req_handle = RequestHandle;
+  ctx->req_type = WnbdReqTypePersistResIn;
+  ctx->req_from = 0;
+
+  dout(20) << *ctx << std::hex
+    << ", action=0x" << (int) ServiceAction
+    << ": start" << dendl;
+
+  // TODO: can/should this be async?
+  auto op = WnbdPerResInOperation(
+    handler->rados_ctx,
+    handler->image,
+    handler->pr_initiator,
+    ServiceAction,
+    ctx->data,
+    &ctx->wnbd_status);
+  op.execute();
+
+  ctx->handler->send_io_response(ctx);
+
+  dout(20) << *ctx << ": submitted" << dendl;
+}
+
+void WnbdHandler::PersistResOut(
+  PWNBD_DISK Disk,
+  UINT64 RequestHandle,
+  UINT8 ServiceAction,
+  UINT8 Scope,
+  UINT8 Type,
+  PVOID Buffer,
+  UINT32 ParameterListLength)
+{
+  WnbdHandler* handler = nullptr;
+  ceph_assert(!WnbdGetUserContext(Disk, (PVOID*)&handler));
+
+  WnbdHandler::IOContext* ctx = new WnbdHandler::IOContext();
+  ctx->handler = handler;
+  ctx->req_handle = RequestHandle;
+  ctx->req_type = WnbdReqTypePersistResOut;
+  ctx->req_size = ParameterListLength;
+  ctx->req_from = 0;
+
+  bufferptr ptr((char*)Buffer, ctx->req_size);
+  ctx->data.push_back(ptr);
+
+  dout(20) << *ctx << std::hex
+    << ", action=0x" << (uint) ServiceAction
+    << ", scope=0x" << (uint) Scope
+    << ", type=0x" << (uint) Type
+    << ", buffer_sz=0x" << (uint) ParameterListLength
+    << ": start" << dendl;
+  // TODO: can/should this be async?
+  auto op = WnbdPerResOutOperation(
+    handler->rados_ctx,
+    handler->image,
+    handler->pr_initiator,
+    ServiceAction,
+    Scope,
+    Type,
+    ctx->data,
+    &ctx->wnbd_status);
+  op.execute();
+
+  ctx->handler->send_io_response(ctx);
 
   dout(20) << *ctx << ": submitted" << dendl;
 }
@@ -430,6 +573,7 @@ int WnbdHandler::start()
 
   wnbd_props.Flags.ReadOnly = readonly;
   wnbd_props.Flags.UnmapSupported = 1;
+  wnbd_props.Flags.PersistResSupported = enable_pr;
   if (rbd_cache_enabled) {
     wnbd_props.Flags.FUASupported = 1;
     wnbd_props.Flags.FlushSupported = 1;
@@ -474,6 +618,12 @@ std::ostream &operator<<(std::ostream &os, const WnbdHandler::IOContext &ctx) {
     break;
   case WnbdReqTypeUnmap:
     os << " TRIM ";
+    break;
+  case WnbdReqTypePersistResIn:
+    os << " PERSISTENT_RESERVE_IN ";
+    break;
+  case WnbdReqTypePersistResOut:
+    os << " PERSISTENT_RESERVE_OUT ";
     break;
   default:
     os << " UNKNOWN(" << ctx.req_type << ") ";

--- a/src/tools/rbd_wnbd/wnbd_handler.h
+++ b/src/tools/rbd_wnbd/wnbd_handler.h
@@ -66,6 +66,7 @@ class WnbdHandler
 private:
   librbd::Image &image;
   std::string instance_name;
+  std::string snap_name;
   uint64_t block_count;
   uint32_t block_size;
   bool readonly;
@@ -77,12 +78,14 @@ private:
 
 public:
   WnbdHandler(librbd::Image& _image, std::string _instance_name,
+              std::string _snap_name,
               uint64_t _block_count, uint32_t _block_size,
               bool _readonly, bool _rbd_cache_enabled,
               uint32_t _io_req_workers,
               uint32_t _io_reply_workers)
     : image(_image)
     , instance_name(_instance_name)
+    , snap_name(_snap_name)
     , block_count(_block_count)
     , block_size(_block_size)
     , readonly(_readonly)
@@ -143,6 +146,8 @@ private:
   };
 
   friend std::ostream &operator<<(std::ostream &os, const IOContext &ctx);
+
+  void generate_naa_id(WNBD_NAA_ID &id);
 
   void send_io_response(IOContext *ctx);
 

--- a/src/tools/rbd_wnbd/wnbd_handler.h
+++ b/src/tools/rbd_wnbd/wnbd_handler.h
@@ -24,6 +24,8 @@
 
 #include "global/global_context.h"
 
+#include "per_res.h"
+
 // TODO: make this configurable.
 #define RBD_WNBD_MAX_TRANSFER 2 * 1024 * 1024
 #define SOFT_REMOVE_RETRY_INTERVAL 2
@@ -64,6 +66,7 @@ public:
 class WnbdHandler
 {
 private:
+  librados::IoCtx rados_ctx;
   librbd::Image &image;
   std::string instance_name;
   std::string snap_name;
@@ -71,25 +74,32 @@ private:
   uint32_t block_size;
   bool readonly;
   bool rbd_cache_enabled;
+  bool enable_pr;
+  std::string pr_initiator;
   uint32_t io_req_workers;
   uint32_t io_reply_workers;
   WnbdAdminHook* admin_hook;
   boost::asio::thread_pool* reply_tpool;
 
 public:
-  WnbdHandler(librbd::Image& _image, std::string _instance_name,
+  WnbdHandler(librados::IoCtx _rados_ctx,
+              librbd::Image& _image,
+              std::string _instance_name,
               std::string _snap_name,
               uint64_t _block_count, uint32_t _block_size,
               bool _readonly, bool _rbd_cache_enabled,
+              bool _enable_pr,
               uint32_t _io_req_workers,
               uint32_t _io_reply_workers)
-    : image(_image)
+    : rados_ctx(_rados_ctx)
+    , image(_image)
     , instance_name(_instance_name)
     , snap_name(_snap_name)
     , block_count(_block_count)
     , block_size(_block_size)
     , readonly(_readonly)
     , rbd_cache_enabled(_rbd_cache_enabled)
+    , enable_pr(_enable_pr)
     , io_req_workers(_io_req_workers)
     , io_reply_workers(_io_reply_workers)
   {
@@ -99,6 +109,7 @@ public:
     // are going to send the IO replies and thus be able to cache Windows
     // OVERLAPPED structures.
     reply_tpool = new boost::asio::thread_pool(_io_reply_workers);
+    pr_initiator = get_pr_initiator();
   }
 
   int resize(uint64_t new_size);
@@ -143,6 +154,8 @@ private:
 
     void set_sense(uint8_t sense_key, uint8_t asc, uint64_t info);
     void set_sense(uint8_t sense_key, uint8_t asc);
+
+    int check_rsv_conflict();
   };
 
   friend std::ostream &operator<<(std::ostream &os, const IOContext &ctx);
@@ -178,6 +191,18 @@ private:
     UINT64 RequestHandle,
     PWNBD_UNMAP_DESCRIPTOR Descriptors,
     UINT32 Count);
+  static void PersistResIn(
+    PWNBD_DISK Disk,
+    UINT64 RequestHandle,
+    UINT8 ServiceAction);
+  static void PersistResOut(
+    PWNBD_DISK Disk,
+    UINT64 RequestHandle,
+    UINT8 ServiceAction,
+    UINT8 Scope,
+    UINT8 Type,
+    PVOID Buffer,
+    UINT32 ParameterListLength);
 
   static constexpr WNBD_INTERFACE RbdWnbdInterface =
   {
@@ -185,6 +210,8 @@ private:
     Write,
     Flush,
     Unmap,
+    PersistResIn,
+    PersistResOut,
   };
 };
 


### PR DESCRIPTION
This is a draft for the persistent reservation v2 implementation.

We intend to tag rbd IO operations with the expected PR generation so that if there's a mismatch (i.e. the PR data changed), we can invalidate the IO operations and either retry or return a PR conflict error.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
